### PR TITLE
Add Nonce to the current KeyMaterial object, global Docker file and change key name in DHPublicKey

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,22 +12,22 @@ RUN /usr/lib/jvm/zulu11/bin/jlink \
     --verbose \
     --add-modules \
         java.base,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument \
-        # java.naming - javax/naming/NamingException
-        # java.desktop - java/beans/PropertyEditorSupport
-        # java.management - javax/management/MBeanServer
-        # java.security.jgss - org/ietf/jgss/GSSException
-        # java.instrument - java/lang/instrument/IllegalClassFormatException
     --compress 2 \
     --strip-debug \
     --no-header-files \
     --no-man-pages \
     --output "$JAVA_MINIMAL"
+
 # Second stage, add only our minimal "JRE" distr and our app
-FROM alpine
+FROM adoptopenjdk/openjdk11
+WORKDIR /app
 ENV JAVA_MINIMAL=/opt/jre
 ENV PATH="$PATH:$JAVA_MINIMAL/bin"
 COPY --from=packager "$JAVA_MINIMAL" "$JAVA_MINIMAL"
-
 EXPOSE 8080
-ADD ./build/libs/forwardsecrecy.jar forwardsecrecy.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","/forwardsecrecy.jar"]
+
+COPY . .
+RUN ./gradlew build
+
+#ADD ./build/libs/forwardsecrecy.jar forwardsecrecy.jar
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","./build/libs/forwardsecrecy.jar"]

--- a/src/main/java/io/yaazhi/forwardsecrecy/dto/DHPublicKey.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/dto/DHPublicKey.java
@@ -17,7 +17,7 @@ public class DHPublicKey{
     String expiry;
     //Dont ask me why this is capital. I am just blindly following the spec ;)
     @NonNull
-    @JsonProperty("Parameter")
+    @JsonProperty("Parameters")
     String parameter;
     @NonNull
     @JsonProperty("KeyValue")

--- a/src/main/java/io/yaazhi/forwardsecrecy/dto/KeyMaterial.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/dto/KeyMaterial.java
@@ -22,4 +22,8 @@ public class KeyMaterial{
     @NonNull
     @JsonProperty("DHPublicKey")
     DHPublicKey dhPublicKey;
+    // Add Nonce as a property for the KeyMaterial object
+    @JsonProperty("Nonce")
+    @NonNull
+    String nonce;
 }


### PR DESCRIPTION
## What?

1) Add Nonce to the current KeyMaterial object

Existing KeyMaterial
```json
"KeyMaterial": {
  "cryptoAlg": "ECDH",
  "curve": "Curve25519",
  "params": "",
  "DHPublicKey": {
    "expiry": "",
    "Parameter": "",
    "KeyValue": ""
  }
}
```

Proposed KeyMaterial structure
```json
"KeyMaterial": {
  "cryptoAlg": "ECDH",
  "curve": "Curve25519",
  "params": "",
  "DHPublicKey": {
    "expiry": "",
    "Parameter": "",
    "KeyValue": ""
  },
  "Nonce": ""
}
```

2) Add global Docker file

3) Change the key name in DHPublicKey from "Parameter" to "Parameters " to comply with the specifications

In ReBIT spec

```json 
"DHPublicKey": {
  "expiry": "2018-12-06T11:39:57.153Z",
  "Parameters": "string",
  "KeyValue": "string"
}
```

In Rahasya library

```json 
"DHPublicKey": {
  "expiry": "2018-12-06T11:39:57.153Z",
  "Parameter": "string",
  "KeyValue": "string"
}
```

## Why?

1) This will help developers to generate Nonce at the time of generating KeyMaterial rather than a separate implementation to generate it. Also helps in keeping the KeyMaterial structure same across all requests and response.

2) This will help developers to build a Docker image without any pre-setup of JDK

3) This change is to be consistent and comply with the ReBIT spec
 
## How?

1) Added a new property Nonce to KeyMaterial class in dto folder. Implemented a 256-bit secure random string and encoded it to generate Nonce in ECCService

2) Download JDK, run gradle build and .jar file to the entry points

3) Change the JSON property name in DHPublicKey.java file in dto folder